### PR TITLE
ci: update docker repository paths to include k8s subdirectory

### DIFF
--- a/.github/workflows/edge-release.yaml
+++ b/.github/workflows/edge-release.yaml
@@ -35,8 +35,8 @@ jobs:
           FIPS_ENABLE: ${{ matrix.fips }}
         run: |
           if [ ${{ matrix.fips }} = "yes" ]; then
-            export REPOSITORY=us-docker.pkg.dev/palette-images-fips/edge
+            export REPOSITORY=us-docker.pkg.dev/palette-images-fips/k8s/edge
           else
-            export REPOSITORY=us-docker.pkg.dev/palette-images/edge
+            export REPOSITORY=us-docker.pkg.dev/palette-images/k8s/edge
           fi
           make docker


### PR DESCRIPTION
## Summary
- Update FIPS docker repository path from `us-docker.pkg.dev/palette-images-fips/edge` to `us-docker.pkg.dev/palette-images-fips/k8s/edge`
- Update non-FIPS docker repository path from `us-docker.pkg.dev/palette-images/edge` to `us-docker.pkg.dev/palette-images/k8s/edge`

## Test plan
- [ ] Verify the workflow runs successfully with the updated repository paths
- [ ] Confirm images are pushed to the correct k8s subdirectory locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)