### PR TITLE
chore: bump version to v1.0.3-spectro-1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL := $(TARGET)
 
 # These will be provided to the target
-VERSION := v1.0.3-spectro-1.0
+VERSION := v1.0.3-spectro-1.1
 
 BUILD := `git rev-parse HEAD`
 


### PR DESCRIPTION
## Summary
- Bump version from `v1.0.3-spectro-1.0` to `v1.0.3-spectro-1.1` in Makefile

## Test plan
- [ ] Verify build uses the updated version string