### PR TITLE
chore: bump version to v1.0.3-spectro-1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL := $(TARGET)
 
 # These will be provided to the target
-VERSION := v1.0.3-spectro-1.2
+VERSION := v1.0.3-spectro-1.3
 
 BUILD := `git rev-parse HEAD`
 


### PR DESCRIPTION
## Summary
- Bump `VERSION` in `Makefile` from `v1.0.3-spectro-1.2` to `v1.0.3-spectro-1.3`.

## Test plan
- [ ] CI build passes
- [ ] Resulting image tag is `v1.0.3-spectro-1.3`