### PR TITLE
chore: use hardened golang builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG GOLANG_VERSION=1.25
 
-FROM --platform=$TARGETPLATFORM us-docker.pkg.dev/palette-images/build-base-images/golang:${GOLANG_VERSION}-alpine as builder
+FROM --platform=$TARGETPLATFORM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang:${GOLANG_VERSION}-alpine as builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG CRYPTO_LIB

--- a/Dockerfile_iptables
+++ b/Dockerfile_iptables
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.25.5-alpine3.23 as dev
+ARG GOLANG_VERSION=1.25
+
+FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang:${GOLANG_VERSION}-alpine as dev
 RUN apk add --no-cache git make
 RUN adduser -D appuser
 COPY . /src/


### PR DESCRIPTION
## Summary
- Switch `Dockerfile` builder stage from `us-docker.pkg.dev/palette-images/build-base-images/golang` to `us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang`.
- Update `Dockerfile_iptables` to use the same hardened registry image and honor `GOLANG_VERSION` (previously hard-coded to `golang:1.25.5-alpine3.23`).

## Test plan
- [ ] CI image build passes for both `Dockerfile` and `Dockerfile_iptables`
- [ ] `GOLANG_VERSION` override (via Makefile / build arg) is respected by both Dockerfiles