### PR TITLE
chore: bump version to v1.0.3-spectro-1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TARGET := kube-vip
 .DEFAULT_GOAL := $(TARGET)
 
 # These will be provided to the target
-VERSION := v1.0.3-spectro-1.3
+VERSION := v1.0.3-spectro-1.4
 
 BUILD := `git rev-parse HEAD`
 


### PR DESCRIPTION
## Summary
- Bump `VERSION` in `Makefile` from `v1.0.3-spectro-1.3` to `v1.0.3-spectro-1.4` to cut a release including #45 (hardened golang builder image) and #46 (grpc/x-net CVE bumps).

## Test plan
- [ ] CI build passes
- [ ] Resulting image tag is `v1.0.3-spectro-1.4`